### PR TITLE
feat(ci): use sha instead of tag

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -26,25 +26,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #v5.8.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
             type=edge
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use specific commit SHAs for all Docker-related actions, improving security and reliability by pinning dependencies to exact versions.

**Dependency pinning for workflow actions:**

* Updated `actions/checkout` usage to pin to commit `08c6903cd8c0fde910a37f88322edcfb5dd907a8` (v5.0.0) instead of a general version tag.
* Updated `docker/metadata-action` usage to pin to commit `c1e51972afc2121e065aed6d45c65596fe445f3f` (v5.8.0).
* Updated `docker/login-action` usage to pin to commit `184bdaa0721073962dff0199f1fb9940f07167d1` (v3.5.0).
* Updated `docker/build-push-action` usage to pin to commit `263435318d21b8e681c14492fe198d362a7d2c83` (v6.18.0).